### PR TITLE
cisco-firepower-management-login

### DIFF
--- a/http/exposed-panels/cisco-firepower-management-login.yaml
+++ b/http/exposed-panels/cisco-firepower-management-login.yaml
@@ -1,0 +1,37 @@
+id: cisco-firepower-management-login
+
+info:
+  name: Cisco Firepower Management Center login - Detect
+  author: Charles D
+  severity: info
+  description: Cisco Firepower Management Centerlogin panel was detected
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    shodan-query: html:"cisco firepower management"
+  tags: console,login,cisco
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/ui/login'
+    
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Cisco Firepower Management Center"
+        part: body
+    
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+         - "'version':\\s*'(\\d+\\.\\d+\\.\\d+)'"


### PR DESCRIPTION
Adding a Cisco firepower management login panel, did not see any in for nuclei.  For shodan query that is the only one that seems to show result